### PR TITLE
Add the birthday announcement functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,5 +157,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 secret.txt
+lv_secret.txt

--- a/resources/birthday_messages.txt
+++ b/resources/birthday_messages.txt
@@ -1,0 +1,20 @@
+Happy birthday to someone who's aging like fine wine – getting better with every passing year!
+Another year older, but trust me, you're also another year cooler. Happy birthday!
+Happy birthday! Remember, the older you get, the better you were.
+Age is just a high score in the game of life. Keep leveling up! Happy birthday!
+Happy birthday! Here's to you, the person who never ages, only levels up!
+You know you're getting older when the candles cost more than the cake! Happy birthday!
+Don't let anyone tell you that getting older is a bad thing. It just means you've got more experience to rock this world! Happy birthday!
+Happy birthday! May your day be filled with laughter, joy, and cake – lots and lots of cake!
+Cheers to another year of gray hairs and wrinkles, but also to a heart full of love and laughter. Happy birthday!
+Happy birthday! Just a friendly reminder that age is simply a state of mind – and you, my friend, have a youthful soul!
+They say age is a matter of the mind. If you don't mind, it doesn't matter! Happy birthday!
+Happy birthday! It's not the years in your life that count; it's the smiles you put on people's faces!
+Congratulations on surviving another trip around the sun! Happy birthday!
+Happy birthday to someone who's aged to perfection, just like a fine cheese or a vintage wine!
+They say you can't have your cake and eat it too, but hey, it's your birthday! Do what you want!
+Another year older means another year wiser. That means you're now an expert at being awesome! Happy birthday!
+Happy birthday! Just remember, age is merely the number of years the world has been enjoying you!
+As you blow out your candles, know that you're not getting older; you're increasing your awesomeness! Happy birthday!
+Don't let anyone tell you that being a year older is a bad thing. You're like a fine wine – getting better with age! Happy birthday!
+Happy birthday! You're not just another year older; you're another year more fantastic!

--- a/resources/prompts.txt
+++ b/resources/prompts.txt
@@ -85,3 +85,11 @@ Go back to the main menu
 #-- check_trivia_score --#
 
 check all your teams scores !
+
+#-- birthday_announcement --#
+
+La Mulți Ani {users} 🎉
+
+{message}
+
+Enjoy {points} Loyalty Points from T5 Social 🎁


### PR DESCRIPTION
This is the birthday announcement functionality based on the feedback we received in the Bot Task Force group.

Each day at midnight the bot will determine which users have their birthday today, then it will display a prompt and award points to these users.

The prompt will be displayed to one or more channels where this functionality is registered. To register a channel, either pass it through the `BIRTHDAY_CHATS` environment variable, or register/unregister it interactively using the `/start_announcing_birthdays` and `/stop_announcing_birthdays` commands.

The users' birthdays are read from the `resources/T5 Community Data_Birthdays.csv` file. The birthday messages themselves are read from `resources/birthday_messages.txt` and passed through the `birthday_announcement` prompt.

This pull request adds the following environment variables;

- `BIRTHDAY_CHATS`, a comma-separated list of chat ids where the bot will announce birthdays by default. Default: empty string
- `BIRTHDAY_POINTS`, an integer specifying how many points to award. Default: 5
- `TIMEZONE`, the timezone that the bot operates under. Default: Europe/Bucharest