### PR TITLE
Add some access rights for master botters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ loyverse_token=
 birthday_chats=
 birthday_points=5
 timezone=Europe/Bucharest
+masters=roblevermusic,AntoineCastel,surely_not_a_bot
+point_masters=roblevermusic

--- a/helpers/access_checker.py
+++ b/helpers/access_checker.py
@@ -1,0 +1,10 @@
+class AccessChecker:
+    def __init__(self, masters: set, point_masters: set):
+        self.masters = masters
+        self.point_masters = point_masters
+
+    def is_master(self, username: str) -> bool:
+        return username in self.masters
+
+    def can_donate_for_free(self, username: str) -> bool:
+        return username in self.point_masters

--- a/helpers/loyverse.py
+++ b/helpers/loyverse.py
@@ -100,7 +100,7 @@ class LoyverseConnector:
 
         customers = self.get_all_customers()
 
-        customer = customers.get(username)
+        customer = self.get_customer_from_username(customers, username)
         new_total_points = customer.get("total_points") - points
 
         if new_total_points < 0:
@@ -117,14 +117,14 @@ class LoyverseConnector:
         customers = self.get_all_customers()
 
         recipient_customer = self.get_customer_from_username(customers, recipient_username)
-        if sender_username != "roblevermusic":  # Rob can send as much points as he wants because he is god 🙏
-            sender_customer = self.get_customer_from_username(customers, sender_username)
-            sender_new_total_points = sender_customer.get("total_points") - points
+        sender_customer = self.get_customer_from_username(customers, sender_username)
 
-            if sender_new_total_points < 0:
-                raise Exception("you cannot donate more points than you have in your balance")
+        sender_new_total_points = sender_customer.get("total_points") - points
 
-            print(self.update_total_points(sender_customer, sender_new_total_points))
+        if sender_new_total_points < 0:
+            raise Exception("you cannot donate more points than you have in your balance")
+
+        print(self.update_total_points(sender_customer, sender_new_total_points))
 
         recipient_new_total_points = recipient_customer.get("total_points") + points
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import pytz
 from telegram.ext import ApplicationBuilder
 from dotenv import load_dotenv
 
+from helpers.access_checker import AccessChecker
 from helpers.loyverse import LoyverseConnector
 from modules.help import HelpModule
 from modules.points import PointsModule
@@ -24,18 +25,25 @@ class MainConfig:
         self.birthday_chats = set([int(chatid) for chatid in os.getenv('birthday_chats', '').split(',') if chatid])
         self.birthday_points = int(os.getenv('birthday_points', 5))
         self.timezone = pytz.timezone(os.getenv('timezone', 'Europe/Bucharest'))
+        self.masters = set([username for username in os.getenv('masters', '').split(',') if username])
+        self.point_masters = set([username for username in os.getenv('point_masters', '').split(',') if username])
 
 
 def main() -> None:
     config = MainConfig()
     lc = LoyverseConnector(config.loyverse_token)
+    ac = AccessChecker(
+        masters=config.masters,
+        point_masters=config.point_masters,
+    )
 
     modules = [
         HelpModule(),
-        PointsModule(lc=lc),
-        RaffleModule(lc=lc),
+        PointsModule(lc=lc, ac=ac),
+        RaffleModule(lc=lc, ac=ac),
         BirthdayModule(
             lc=lc,
+            ac=ac,
             default_chats=config.birthday_chats,
             points_to_award=config.birthday_points,
             timezone=config.timezone,

--- a/modules/birthday.py
+++ b/modules/birthday.py
@@ -60,7 +60,7 @@ class BirthdayModule:
         await update.message.reply_text("I will no longer announce birthdays in this chat.")
 
     async def __process_birthdays(self, context: ContextTypes.DEFAULT_TYPE) -> None:
-        current_date = datetime.now()
+        current_date = datetime.now(self.timezone)
         current_birthday = f"{current_date.month}/{current_date.day}"
 
         if current_birthday not in birthdays:

--- a/modules/birthday.py
+++ b/modules/birthday.py
@@ -7,6 +7,7 @@ import random
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
+from helpers.access_checker import AccessChecker
 from helpers.loyverse import LoyverseConnector
 from helpers.prompt_parser import parse
 
@@ -31,8 +32,9 @@ with open('resources/T5 Community Data_Birthdays.csv', 'r') as csvfile:
 
 
 class BirthdayModule:
-    def __init__(self, lc: LoyverseConnector, default_chats: set = None, points_to_award: int = 5, timezone: pytz.timezone = None):
+    def __init__(self, lc: LoyverseConnector, ac: AccessChecker, default_chats: set = None, points_to_award: int = 5, timezone: pytz.timezone = None):
         self.lc = lc
+        self.ac = ac
         self.chats = (default_chats or set()).copy()
         self.points_to_award = points_to_award
         self.timezone = timezone
@@ -44,10 +46,16 @@ class BirthdayModule:
         application.job_queue.run_daily(self.__process_birthdays, time(0, 0, 0, 0, self.timezone))
 
     async def __start_announcing_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self.ac.is_master(update.effective_user.username):
+            return
+
         self.chats.add(update.effective_chat.id)
         await update.message.reply_text("I will announce birthdays in this chat, every day at midnight.")
 
     async def __stop_announcing_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self.ac.is_master(update.effective_user.username):
+            return
+
         self.chats.remove(update.effective_chat.id)
         await update.message.reply_text("I will no longer announce birthdays in this chat.")
 

--- a/modules/raffle.py
+++ b/modules/raffle.py
@@ -3,12 +3,14 @@ from collections import Counter
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
+from helpers.access_checker import AccessChecker
 from helpers.loyverse import LoyverseConnector
 
 
 class RaffleModule:
-    def __init__(self, lc: LoyverseConnector):
+    def __init__(self, lc: LoyverseConnector, ac: AccessChecker):
         self.lc = lc
+        self.ac = ac
         self.entries = []
 
     def install(self, application: Application) -> None:
@@ -38,8 +40,8 @@ class RaffleModule:
 
     # A command for god to edit the list for the raffle
     async def __raffle_list(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        username = update.message.from_user.username
-        if username == "roblevermusic":
-            self.entries = context.args
+        if not self.ac.is_master(update.effective_user.username):
+            return
 
+        self.entries = context.args
         print(self.entries)


### PR DESCRIPTION
We need to be able to restrict the usage of specific commands to a few select users. Previously we were relying on the hardcoded name "roblevermusic" to accomplish this.

The solution I propose is to store the names of these master botters in environment variables. I have added 2 variables for this:

- `masters` for users who are able to issue "admin" commands, such as updating the raffle list or registering/unregistering the birthdays. This should be Andrei, Antoine and Rob.
- `point_masters` for users who are able to donate without losing points. This should just be Rob.

The variables above will need to be added to Heroku (see `.env.example` for the exact format).

These environment variables are not checked directly in the calling code, but rather they are loaded into an AccessChecker service that is passed to modules.

For a better separation of concerns across our code, I suggest the following guidelines for future development:

- Whenever we need access rights for something, we need to add them through the AccessChecker. As the bot develops, there may come a moment when we will need a proper RBAC solution and it will be easier to implement if we keep everything in that class.
- The AccessChecker should be used within modules and within commands, but not within helpers such as LoyverseConnector
- LoyverseConnector is just a library for connecting to Loyverse. This class should not know anything about access rights, nor should it output any bot-specific messages. It should be isolated from the rest of the project. For this purpose, I made it so that when point masters (Rob) want to donate points, an `add_points` call is used instead of `donate_points` and this decision is made within the command.
- The commands are the place to parse the input parameters and to handle errors, including changing the technical error messages to user-friendly ones