### PR TITLE
Track user visits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ point_masters=roblevermusic
 google_api_credentials=
 google_spreadsheet_key=
 xmas_loyverse_id=
+visits_to_points={"5": 5, "10": 10, "20": 20}

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -3,11 +3,14 @@ from datetime import datetime
 from copy import deepcopy
 from typing import Optional
 
+from data.models.user_role import UserRole
+
 
 @dataclass(frozen=True)
 class User:
     full_name: str
     aliases: list[str] = field(default_factory=list)
+    role: UserRole = UserRole.CHAMPION
     telegram_username: str = ''
     birthday: Optional[str] = None
     telegram_id: Optional[int] = None

--- a/data/models/user.py
+++ b/data/models/user.py
@@ -13,6 +13,8 @@ class User:
     telegram_id: Optional[int] = None
     loyverse_id: Optional[str] = None
     last_private_chat: Optional[datetime] = None
+    last_visit: Optional[datetime] = None
+    recent_visits: int = 0
 
     @property
     def first_name(self) -> str:

--- a/data/models/user_role.py
+++ b/data/models/user_role.py
@@ -1,0 +1,7 @@
+from enum import Enum, unique
+
+
+@unique
+class UserRole(Enum):
+    CHAMPION = "champion"
+    STAFF = "staff"

--- a/data/repositories/user.py
+++ b/data/repositories/user.py
@@ -14,6 +14,9 @@ class UserRepository:
     def get_by_birthday(self, birthday: Union[str, date, datetime]) -> list[User]:
         pass
 
+    def get_by_loyverse_id(self, loyverse_id: str) -> Optional[User]:
+        pass
+
     def search(self, query: str) -> set[User]:
         pass
 

--- a/helpers/visit_calculator.py
+++ b/helpers/visit_calculator.py
@@ -1,0 +1,120 @@
+import logging
+from datetime import datetime, date, timedelta
+from itertools import groupby
+from typing import Optional, Tuple
+
+from data.models.user import User
+
+from modules.base_module import BaseModule
+from helpers.points import Points
+
+logger = logging.getLogger(__name__)
+
+Checkpoints = dict[int, Points]
+ReachedCheckpoints = dict[date, Checkpoints]
+
+
+class VisitCalculator(BaseModule):
+    def __init__(self, checkpoints: Checkpoints):
+        # Make sure the checkpoints are sorted
+        self._checkpoints = dict(sorted(checkpoints.items()))
+
+    @staticmethod
+    def get_visits_this_month(user: User, current_month: datetime) -> int:
+        if user.last_visit and VisitCalculator.month(user.last_visit) >= VisitCalculator.month(current_month):
+            return user.recent_visits
+
+        return 0
+
+    def get_next_checkpoint(self, visits: int) -> Optional[Tuple[int, Points]]:
+        for checkpoint, points in self._checkpoints.items():
+            if checkpoint > visits:
+                return checkpoint, points
+        return None
+
+    def add_visits(self, raw_visits: list[Tuple[User, datetime]], current_month: datetime) -> dict[User, ReachedCheckpoints]:
+        if not raw_visits:
+            return {}
+
+        current_month = VisitCalculator.month(current_month)
+
+        # Group the visits by User
+        sorted_visits = sorted(raw_visits, key=lambda visit: visit[0].full_name)
+        grouped_visits = groupby(sorted_visits, key=lambda visit: visit[0])
+        user_visits = {user: [visit[1] for visit in visits] for user, visits in grouped_visits}
+
+        # Add the visits to each user
+        raw_updates = [self._add_user_visits(user, visits, current_month) for user, visits in user_visits.items()]
+        updates = {update[0]: update[1] for update in raw_updates if update}
+        return updates
+
+    def _add_user_visits(self, user: User, raw_visits: list[datetime], current_month: date) -> Optional[Tuple[User, ReachedCheckpoints]]:
+        clean_visits = VisitCalculator._clean_visits(raw_visits, user.last_visit)
+        if not clean_visits:
+            return None
+
+        # Grouping the visits by month helps us deal with various edge cases
+        # 1. We have crossed from one month into another and we need to start the count again from 0 (most common)
+        # 2. The visits span more than 1 month (extremely rare edge case)
+        #    E.g. This is possible if we last checked on November 30th at 12:00 and it's now December 1st at 12:00
+        #    Some visits could have come in during this 24 hour interval and they would be in different months
+        # 3. The bot has been shut down for a while and we are dealing with an incoming flux of historical data
+        #    spanning many months, and we need to grant partial points for one month and full points for the rest
+        visits_by_month = {}
+        if user.last_visit:
+            visits_by_month[VisitCalculator.month(user.last_visit)] = user.recent_visits
+
+        month_checkpoints = {}
+        for month, visits in VisitCalculator._count_visits_by_month(clean_visits).items():
+            old_count = visits_by_month.get(month, 0)
+            new_count = old_count + visits
+            visits_by_month[month] = new_count
+            checkpoints = self._reach_checkpoints(old_count, new_count)
+            if checkpoints:
+                month_checkpoints[month] = checkpoints
+
+        updated_user = user.copy(
+            recent_visits=visits_by_month.get(current_month, 0),
+            last_visit=clean_visits[-1],
+        )
+
+        return updated_user, month_checkpoints
+
+    @staticmethod
+    def _clean_visits(visits: list[datetime], last_visit: Optional[datetime]) -> list[datetime]:
+        # Clean up the list of raw visits by:
+        # - Removing old visits
+        # - Sorting them by date
+        # - Removing duplicate visits
+
+        # Keep only visits that are newer than the user's last visit
+        new_visits = [visit for visit in visits if visit > last_visit] if last_visit else visits
+        if not new_visits:
+            return []
+
+        new_visits = sorted(new_visits)
+
+        # Keep only visits that happen more than 8 hours after each other
+        distance = timedelta(hours=8)
+
+        distinct_visits = []
+        next_allowed_visit = last_visit + distance if last_visit else new_visits[0]
+        for visit in new_visits:
+            if visit >= next_allowed_visit:
+                distinct_visits.append(visit)
+                next_allowed_visit = visit + distance
+
+        return distinct_visits
+
+    @staticmethod
+    def _count_visits_by_month(visits: list[datetime]) -> dict[date, int]:
+        # Group by month and count the visits
+        visits_grouped_by_month = groupby(sorted(visits), key=lambda visit: VisitCalculator.month(visit))
+        return {month: len(list(visits)) for month, visits in visits_grouped_by_month}
+
+    def _reach_checkpoints(self, start: int, end: int) -> Checkpoints:
+        return {visits: points for visits, points in self._checkpoints.items() if start < visits <= end}
+
+    @staticmethod
+    def month(value: datetime) -> date:
+        return value.date().replace(day=1)

--- a/integrations/google/sheet_user_repository.py
+++ b/integrations/google/sheet_user_repository.py
@@ -66,6 +66,9 @@ class GoogleSheetUserRepository(UserRepository):
         self.save_all([user])
 
     def save_all(self, users: list[User]) -> None:
+        if not users:
+            return
+
         with self.lock.gen_wlock():
             diff_data = {}
             for user in users:

--- a/integrations/google/sheet_user_repository.py
+++ b/integrations/google/sheet_user_repository.py
@@ -8,6 +8,7 @@ from readerwriterlock import rwlock
 
 from data.repositories.user import UserRepository
 from data.models.user import User
+from data.models.user_role import UserRole
 
 from integrations.google.handle import Handle
 from integrations.google.sheet_database import GoogleSheetDatabase
@@ -152,6 +153,7 @@ class GoogleSheetUserRepository(UserRepository):
         return User(
             full_name=row.get('full_name', '').strip(),
             aliases=GoogleSheetUserRepository._parse_aliases(row.get('aliases', '')),
+            role=GoogleSheetUserRepository._parse_user_role(row.get('role', '')),
             telegram_username=row.get('telegram_username', '').strip(),
             birthday=row.get('birthday', ''),
             telegram_id=GoogleSheetUserRepository._parse_int(row.get('telegram_id', '')),
@@ -166,6 +168,7 @@ class GoogleSheetUserRepository(UserRepository):
         return {
             'full_name': user.full_name,
             'aliases': ','.join(user.aliases),
+            'role': user.role.value.capitalize(),
             'telegram_username': user.telegram_username,
             'birthday': user.birthday,
             'telegram_id': user.telegram_id,
@@ -198,3 +201,10 @@ class GoogleSheetUserRepository(UserRepository):
     def _parse_aliases(alias_string: str) -> list[str]:
         clean = [alias.strip() for alias in alias_string.split(',')]
         return [alias for alias in clean if alias]
+
+    @staticmethod
+    def _parse_user_role(user_role_string: str) -> Optional[UserRole]:
+        try:
+            return UserRole(user_role_string.strip().lower())
+        except ValueError:
+            return UserRole.CHAMPION

--- a/integrations/google/sheet_user_repository.py
+++ b/integrations/google/sheet_user_repository.py
@@ -156,7 +156,9 @@ class GoogleSheetUserRepository(UserRepository):
             birthday=row.get('birthday', ''),
             telegram_id=GoogleSheetUserRepository._parse_int(row.get('telegram_id', '')),
             loyverse_id=row.get('loyverse_id', '').strip(),
-            last_private_chat=self._parse_datetime(row.get('last_private_chat', '').strip())
+            last_private_chat=self._parse_datetime(row.get('last_private_chat', '').strip()),
+            last_visit=self._parse_datetime(row.get('last_visit', '').strip()),
+            recent_visits=GoogleSheetUserRepository._parse_int(row.get('recent_visits', '')) or 0,
         )
 
     @staticmethod
@@ -168,7 +170,9 @@ class GoogleSheetUserRepository(UserRepository):
             'birthday': user.birthday,
             'telegram_id': user.telegram_id,
             'loyverse_id': user.loyverse_id,
-            'last_private_chat': user.last_private_chat.strftime('%Y-%m-%d %H:%M:%S') if user.last_private_chat else None
+            'last_private_chat': user.last_private_chat.strftime('%Y-%m-%d %H:%M:%S') if user.last_private_chat else None,
+            'last_visit': user.last_visit.strftime('%Y-%m-%d %H:%M:%S') if user.last_visit else None,
+            'recent_visits': user.recent_visits,
         }
 
     @staticmethod

--- a/integrations/google/sheet_user_repository.py
+++ b/integrations/google/sheet_user_repository.py
@@ -24,6 +24,7 @@ class GoogleSheetUserRepository(UserRepository):
         self.users_by_telegram_id: dict[int, UserHandle] = {}
         self.users_by_telegram_name: dict[str, UserHandle] = {}
         self.users_by_birthday: dict[str, list[UserHandle]] = {}
+        self.users_by_loyverse_id: dict[str, list[UserHandle]] = {}
         self.users_search: dict[str, set[UserHandle]] = {}
 
         # The repository data can be read and refreshed from different threads,
@@ -45,6 +46,10 @@ class GoogleSheetUserRepository(UserRepository):
         with self.lock.gen_rlock():
             date_string = birthday if isinstance(birthday, str) else birthday.strftime('%m-%d')
             return Handle.unwrap_list(self.users_by_birthday.get(date_string, []))
+
+    def get_by_loyverse_id(self, loyverse_id: str) -> Optional[User]:
+        with self.lock.gen_rlock():
+            return self.users_by_loyverse_id.get(loyverse_id, Handle(None)).inner
 
     def search(self, query: str) -> set[User]:
         with self.lock.gen_rlock():
@@ -98,6 +103,7 @@ class GoogleSheetUserRepository(UserRepository):
             self.users_by_full_name = {handle.inner.full_name: handle for handle in self.users if handle.inner.full_name}
             self.users_by_telegram_id = {handle.inner.telegram_id: handle for handle in self.users if handle.inner.telegram_id}
             self.users_by_telegram_name = {handle.inner.telegram_username: handle for handle in self.users if handle.inner.telegram_username}
+            self.users_by_loyverse_id = {handle.inner.loyverse_id: handle for handle in self.users if handle.inner.loyverse_id}
 
             users_with_birthday = [handle for handle in self.users if handle.inner.birthday]
             sorted_birthdays = sorted(users_with_birthday, key=lambda handle: handle.inner.birthday)

--- a/integrations/loyverse/api.py
+++ b/integrations/loyverse/api.py
@@ -33,11 +33,17 @@ class LoyverseApi:
         return self._get_customer(user).points
 
     def add_points(self, user: User, points: Points) -> None:
+        if points.is_zero():
+            return
+
         customer = self._get_customer(user)
         customer.points += points
         self._save_customer(customer)
 
     def remove_points(self, user: User, points: Points) -> None:
+        if points.is_zero():
+            return
+
         customer = self._get_customer(user)
         if customer.points < points:
             raise InsufficientFundsError("You don't have enough points")

--- a/integrations/loyverse/receipt.py
+++ b/integrations/loyverse/receipt.py
@@ -1,0 +1,55 @@
+import pytz
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Receipt:
+    receipt_number: str
+    receipt_type: str
+    created_at: datetime
+    receipt_date: datetime
+    updated_at: datetime
+    source: str
+    total_money: float
+    total_tax: float
+    points_earned: float
+    points_deducted: float
+    points_balance: float
+    total_discount: float
+    employee_id: str
+    store_id: str
+    pos_device_id: str
+
+    note: Optional[str] = None
+    refund_for: Optional[str] = None
+    order: Optional[str] = None
+    cancelled_at: Optional[datetime] = None
+    customer_id: Optional[str] = None
+    dining_option: Optional[str] = None
+
+    tip: float = 0.0
+    surcharge: float = 0.0
+
+    total_discounts: list[dict] = field(default_factory=list)
+    total_taxes: list[dict] = field(default_factory=list)
+
+    line_items: list[dict] = field(default_factory=list)
+    payments: list[dict] = field(default_factory=list)
+
+    @staticmethod
+    def from_json(data: dict, timezone: Optional[pytz.timezone] = None) -> "Receipt":
+        return Receipt(**(data | {
+            'created_at': Receipt._parse_datetime(data['created_at'], timezone),
+            'receipt_date': Receipt._parse_datetime(data['receipt_date'], timezone),
+            'updated_at': Receipt._parse_datetime(data['updated_at'], timezone),
+        }))
+
+    @staticmethod
+    def _parse_datetime(date_string_utc: str, timezone: Optional[pytz.timezone]) -> datetime:
+        datetime_utc = datetime.fromisoformat(date_string_utc.replace('Z', '+00:00'))
+        return datetime_utc.astimezone(timezone) if timezone else datetime_utc
+

--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ from integrations.google.sheet_user_repository import GoogleSheetUserRepository
 from modules.help import HelpModule
 from modules.points import PointsModule
 from modules.donate import DonateModule
-from modules.xmas import XmasModule
 from modules.raffle import RaffleModule
 from modules.birthday import BirthdayModule
 from modules.events import EventsModule
@@ -83,7 +82,6 @@ def main() -> None:
             timezone=config.timezone,
         ),
         EventsModule(repository=event_repository, timezone=config.timezone, ac=ac),
-        XmasModule(loy=loy, ac=ac, users=user_repository, xmas_loyverse_id=config.xmas_loyverse_id),
         TrackingModule(users=user_repository),
     ]
 

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ def main() -> None:
             loy=loy,
             ac=ac,
             users=user_repository,
-            default_chats=config.announcement_chats,
+            announcement_chats=config.announcement_chats,
             points_to_award=config.birthday_points,
             timezone=config.timezone,
         ),

--- a/messages/visits_checkpoints.py
+++ b/messages/visits_checkpoints.py
@@ -1,0 +1,32 @@
+visits_checkpoints = {
+    5: [
+        "High-five! We knew you loved us, but now it's official – you're practically family!",
+        "You've hit the 'Fab Five' mark. Your dedication to T5 is so commendable; we're considering giving Mici a tattoo with your name!",
+        "Boom! You've just hit the 'Fantastic Five.' You're not just a champion; you're a rockstar!",
+        "Five visits is impressive – you're like the James Bond of T5 Champions. Shaken, not stirred by our hospitality, we hope!",
+        "Five visits in a month - if there were a Nobel Prize for hostel loyalty, we would nominate you for sure!",
+        "High-five! Your dedication is like WiFi – it never wavers, and we love it!",
+        "High-five! If there were an Olympic sport for hostel visits, you'd be taking home the gold!",
+        "Five visits – you're a superhero of hospitality appreciation. Cape not included, but you've earned it in spirit!",
+        "Five visits in a month – do you have a secret teleporter directly to our doorstep?",
+        "You've officially joined the 'High Five Heroes'! We're starting to think you have a GPS set to our front door – not that we mind!",
+        "You've reached the 'Frequent Flyer Five' milestone. We're pretty sure your passport has a permanent stamp from our hostel now.",
+        "Brace yourself – you're now part of the 'Five-Time Fiesta.' Your dedication is legendary!"
+    ],
+    10: [
+        "Double digits, baby! You're now a certified 'Perfect Ten' enthusiast. We're thinking of adding a star to our logo just for you.",
+        "Hold on to your hats, folks! Ten visits in a month – are you sure you don't have a secret room here?",
+        "Brace yourself; you've just become the 'Hostel Hottie at Ten.' Our doors are always open for the hottest champions, and you've secured your spot!",
+        "You've entered the 'Penthouse of Patrons'! Ten visits in a month? We might need to create a new VIP level just for you!",
+        "Buckle up, because you're now a member of the 'Perfect Ten Club'. We're considering making a bronze statue of you right next to our reception. Strike a pose!",
+        "Alert the press! We've got a 'Ten-Time Trailblazer' in our midst. Your loyalty deserves a standing ovation and possibly a Hollywood adaptation of your adventures.",
+        "You've reached the 'Ten-Time Wonder' status. If we had a red carpet, it would be rolled out just for you. You're the VIP of VIPs!",
+        "We're not sure if you're a guest or a magician, but either way, you've just pulled off the 'Ten-Time Sorcery'."
+    ],
+    20: [
+        "Epic alert! You've reached the 'Double-Deca-Dynamo' status. We're pretty sure you're part-time staff at this point – any chance you can start tomorrow?",
+        "We bow down to the 'Hostel Guru.' Twenty visits? You're not a champion; you're part of the furniture – in a good way!",
+        "Hold onto your hats, folks – we've got a 'Twenty-Time Tycoon' in the building! Your loyalty is so legendary; we're thinking of naming our next room after you.",
+        "What in the wanderlust! You're not just a champion; you're a 'Hostel Hercules.' Twenty visits is Herculean, and we're in awe of your globetrotting prowess.",
+    ]
+}

--- a/modules/birthday.py
+++ b/modules/birthday.py
@@ -93,12 +93,7 @@ class BirthdayModule(BaseModule):
             logger.warning('There are no users to include in the birthday announcement.')
             return
 
-        usernames = [f"@{user.telegram_username}" for user in users]
-
-        if len(usernames) == 1:
-            users_text = usernames[0]
-        else:
-            users_text = ', '.join(usernames[0:-1]) + ' and ' + usernames[-1]
+        users_text = BirthdayModule.__enumerate([BirthdayModule.__message_name(user) for user in users])
 
         announcement = prompts.get('birthday_announcement').format(
             users=users_text,
@@ -110,3 +105,12 @@ class BirthdayModule(BaseModule):
 
         for chat_id in self.chats:
             await context.bot.send_message(chat_id, announcement)
+
+    @staticmethod
+    def __message_name(user: User) -> str:
+        name = user.main_alias or user.first_name
+        return f"{name} / @{user.telegram_username}"
+
+    @staticmethod
+    def __enumerate(lst: list[str]) -> str:
+        return (', '.join(lst[:-1]) + ' and ' + lst[-1]) if len(lst) > 1 else lst[0]

--- a/modules/birthday.py
+++ b/modules/birthday.py
@@ -1,5 +1,6 @@
 import logging
 import pytz
+from typing import Optional
 from datetime import datetime, time
 import random
 
@@ -25,75 +26,55 @@ with open("resources/birthday_messages.txt", "r") as file:
 
 
 class BirthdayModule(BaseModule):
-    def __init__(self, loy: LoyverseApi, ac: AccessChecker, users: UserRepository, default_chats: set = None, points_to_award: Points = Points(5), timezone: pytz.timezone = None):
-        self.loy = loy
-        self.ac = ac
-        self.users = users
-        self.chats = (default_chats or set()).copy()
-        self.points_to_award = points_to_award
-        self.timezone = timezone
+    def __init__(self, loy: LoyverseApi, ac: AccessChecker, users: UserRepository, announcement_chats: set[int] = None, points_to_award: Points = Points(5), timezone: Optional[pytz.timezone] = None):
+        self.loy: LoyverseApi = loy
+        self.ac: AccessChecker = ac
+        self.users: UserRepository = users
+        self.announcement_chats: set[int] = (announcement_chats or set()).copy()
+        self.points_to_award: Points = points_to_award
+        self.timezone: Optional[pytz.timezone] = timezone
 
     def install(self, application: Application) -> None:
-        application.add_handler(CommandHandler("start_announcing_birthdays", self.__start_announcing_birthdays))
-        application.add_handler(CommandHandler("stop_announcing_birthdays", self.__stop_announcing_birthdays))
-        application.add_handler(CommandHandler("force_announce_birthdays", self.__force_announce_birthdays, filters.ChatType.PRIVATE))
+        application.add_handler(CommandHandler('force_announce_birthdays', self._force_announce_birthdays, filters.ChatType.PRIVATE))
 
         daily_time = time(0, 0, 0, 0, self.timezone)
-        application.job_queue.run_daily(self.__process_birthdays, daily_time)
+        application.job_queue.run_daily(self._process_birthdays, daily_time)
 
-        logger.info(f"Birthday module installed with config: chats: {self.chats} / points_to_award: {self.points_to_award} / timezone: {self.timezone} / daily_time: {daily_time}")
+        logger.info("Birthday module installed")
 
-    async def __start_announcing_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _force_announce_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if not self.ac.is_master(update.effective_user.username):
             return
 
-        self.chats.add(update.effective_chat.id)
-        await update.message.reply_text("I will announce birthdays in this chat, every day at midnight.")
-        logger.info(f'Birthdays will be announced to {self.chats}')
+        await self._process_birthdays(context)
 
-    async def __stop_announcing_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        if not self.ac.is_master(update.effective_user.username):
-            return
-
-        self.chats.remove(update.effective_chat.id)
-        await update.message.reply_text("I will no longer announce birthdays in this chat.")
-        logger.info(f'Birthdays will be announced to {self.chats}')
-
-    async def __force_announce_birthdays(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        if not self.ac.is_master(update.effective_user.username):
-            return
-
-        await self.__process_birthdays(context)
-
-    async def __process_birthdays(self, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def _process_birthdays(self, context: ContextTypes.DEFAULT_TYPE) -> None:
         current_date = datetime.now(self.timezone)
-        current_birthday = f"{current_date.month}-{current_date.day}"
-        logger.info(f"It is now {current_date} . Processing birthdays for {current_birthday} .")
+        logger.info(f"Processing birthdays for {current_date}.")
 
-        users = self.users.get_by_birthday(current_birthday)
+        users = self.users.get_by_birthday(current_date)
         if not users:
             logger.info("No users have birthdays today")
             return
 
         logger.info(f"The following users have birthdays today: {users}")
 
-        self.__add_points(users)
-        await self.__announce_birthdays(users, context)
+        self._add_points(users)
+        await self._announce_birthdays(users, context)
 
-    def __add_points(self, users: list[User]) -> None:
+    def _add_points(self, users: list[User]) -> None:
         for user in users:
             self.loy.add_points(user, self.points_to_award)
 
-    async def __announce_birthdays(self, users: list[User], context: ContextTypes.DEFAULT_TYPE) -> None:
-        if not self.chats:
+    async def _announce_birthdays(self, users: list[User], context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self.announcement_chats:
             logger.warning('There are no chats to announce the birthdays to.')
             return
 
         if not users:
-            logger.warning('There are no users to include in the birthday announcement.')
             return
 
-        users_text = BirthdayModule.__enumerate([BirthdayModule.__message_name(user) for user in users])
+        users_text = BirthdayModule._enumerate([BirthdayModule._message_name(user) for user in users])
 
         announcement = prompts.get('birthday_announcement').format(
             users=users_text,
@@ -101,16 +82,14 @@ class BirthdayModule(BaseModule):
             points=self.points_to_award
         )
 
-        logger.info(announcement)
-
-        for chat_id in self.chats:
+        for chat_id in self.announcement_chats:
             await context.bot.send_message(chat_id, announcement)
 
     @staticmethod
-    def __message_name(user: User) -> str:
+    def _message_name(user: User) -> str:
         name = user.main_alias or user.first_name
         return f"{name} / @{user.telegram_username}"
 
     @staticmethod
-    def __enumerate(lst: list[str]) -> str:
+    def _enumerate(lst: list[str]) -> str:
         return (', '.join(lst[:-1]) + ' and ' + lst[-1]) if len(lst) > 1 else lst[0]

--- a/modules/donate.py
+++ b/modules/donate.py
@@ -129,6 +129,9 @@ class DonateModule(BaseModule):
         while (i < len(args)) and (not args[i].isnumeric()):
             i += 1
 
+        if i == 0:
+            raise CommandSyntaxError()
+
         if i >= len(args):
             raise CommandSyntaxError()
 

--- a/modules/visits.py
+++ b/modules/visits.py
@@ -1,0 +1,159 @@
+import logging
+import pytz
+import random
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from telegram import Update, InlineKeyboardButton
+from telegram.constants import ChatType
+from telegram.ext import Application, ContextTypes, CommandHandler, CallbackQueryHandler
+
+from data.models.user import User
+from data.repositories.user import UserRepository
+
+from modules.base_module import BaseModule
+from helpers.points import Points
+from helpers.visit_calculator import VisitCalculator, ReachedCheckpoints
+from helpers.exceptions import UserFriendlyError
+
+from integrations.loyverse.api import LoyverseApi
+from integrations.loyverse.receipt import Receipt
+
+from messages.visits_checkpoints import visits_checkpoints
+
+logger = logging.getLogger(__name__)
+
+
+class VisitsModule(BaseModule):
+    def __init__(self, loy: LoyverseApi, users: UserRepository, vc: VisitCalculator, timezone: pytz.timezone = None):
+        self.loy = loy
+        self.users = users
+        self.timezone = timezone
+        self.vc = vc
+
+        # We start checking for visits from the first day of the current month
+        self.last_check = datetime.now(self.timezone).replace(day=1, hour=0, minute=0, second=0)
+
+    def install(self, application: Application) -> None:
+        application.add_handlers([
+            CommandHandler("visits", self._status),
+            CallbackQueryHandler(self._status, pattern="^visits/status"),
+        ])
+
+        application.job_queue.run_once(callback=self._update_visits, when=0)
+        application.job_queue.run_repeating(callback=self._update_visits, interval=60 * 5)
+
+        logger.info(f"Visits module installed")
+
+    def get_menu_buttons(self) -> list[list[InlineKeyboardButton]]:
+        return [
+            [InlineKeyboardButton('Check Your Visits', callback_data='visits/status')],
+        ]
+
+    async def _status(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        try:
+            user = self._validate_user(update)
+
+            right_now = datetime.now(self.timezone)
+            visits_this_month = VisitCalculator.get_visits_this_month(user, right_now)
+
+            reply_parts = []
+            if visits_this_month:
+                reply_parts.append(f"You visited T5 {user.recent_visits} times this month!")
+            else:
+                reply_parts.append(f"I haven't seen you at T5 at all this month! Or maybe you're there right now for the first time?")
+
+            if user.last_visit:
+                if user.last_visit < right_now - timedelta(days=365):
+                    date_format = '%d %B %Y'
+                elif user.last_visit < right_now - timedelta(days=7):
+                    date_format = '%d %B'
+                else:
+                    date_format = '%A, %d %B'
+                reply_parts.append(f"The last time I saw you there was on {user.last_visit.strftime(date_format)}.")
+
+            next_checkpoint = self.vc.get_next_checkpoint(visits_this_month)
+            if next_checkpoint:
+                visits_until_checkpoint = next_checkpoint[0] - visits_this_month
+                more = 'more ' if visits_this_month else ''
+                reply_parts.append(f"If you visit {visits_until_checkpoint} {more}times, you will be rewarded with {next_checkpoint[1]} points!")
+
+            reply_parts.append(f"Please remember to pay your tab at the bar so I can tell you've been around.")
+
+            reply = "\n\n".join(reply_parts)
+        except UserFriendlyError as e:
+            reply = str(e)
+        except Exception as e:
+            logger.exception(e)
+            reply = f"BeeDeeBeeBoop 🤖 Error : {e}"
+
+        if update.effective_chat.type != ChatType.PRIVATE:
+            reply += "\n\n" + 'You can also <a href="https://t.me/T5socialBot?start=help">talk to me directly</a> to check your points!'
+
+        if update.callback_query:
+            await update.callback_query.answer()
+            await update.callback_query.edit_message_text(reply)
+        else:
+            await update.message.reply_html(reply)
+
+    async def _update_visits(self, context: ContextTypes.DEFAULT_TYPE) -> None:
+        # This function may take several seconds to run, so it's important that we sample the time at the start
+        right_now = datetime.now(self.timezone)
+
+        # Load fresh visits that came in since the last time we checked
+        raw_visits = self.load_visits(self.last_check)
+        updates = self.vc.add_visits(raw_visits, right_now)
+
+        # Save the resulting user data to the repository
+        self.users.save_all(list(updates.keys()))
+
+        # Send messages to users about the points they received
+        await self._send_messages(updates, context)
+
+        # Remember when we last retrieved new information
+        self.last_check = right_now
+
+    def load_visits(self, since: datetime) -> list[Tuple[User, datetime]]:
+        since = since.replace(tzinfo=self.timezone)
+
+        # Load the receipts and convert them into visits (User + creation date)
+        receipts = self.loy.get_receipts(since)
+        raw_visits = [self._receipt_to_visit(receipt) for receipt in receipts]
+        return [visit for visit in raw_visits if visit]
+
+    def _receipt_to_visit(self, receipt: Receipt) -> Optional[Tuple[User, datetime]]:
+        if not receipt.customer_id:
+            return None
+
+        user = self.users.get_by_loyverse_id(receipt.customer_id)
+        if not user:
+            return None
+
+        return user, receipt.created_at
+
+    async def _send_messages(self, updates: dict[User, ReachedCheckpoints], context: ContextTypes.DEFAULT_TYPE):
+        updates_with_points = {user: points for user, points in updates.items() if points}
+        for user, month_checkpoints in updates_with_points.items():
+            for month, checkpoints in month_checkpoints.items():
+                total_points = sum(checkpoints.values(), start=Points(0))
+                a_total_of = 'a total of ' if len(checkpoints) > 1 else ''
+                self.loy.add_points(user, total_points)
+                print(f"{user.full_name} receives {a_total_of}{total_points} points for visits in {month.strftime('%B')}")
+
+                if user.telegram_id:
+                    max_checkpoint = max(checkpoints.keys())
+                    messages = visits_checkpoints.get(max_checkpoint, [])
+                    message = (random.choice(messages) + "\n\n") if messages else None
+                    announcement = f"{message}For your visits in {month.strftime('%B')} you receive {a_total_of}{total_points} points!"
+                    await context.bot.send_message(user.telegram_id, announcement)
+
+    def _validate_user(self, update: Update) -> User:
+        sender_name = update.effective_user.username
+        if not sender_name:
+            raise UserFriendlyError("I don't really know who you are - you first need to create a username in Telegram.")
+
+        sender = self.users.get_by_telegram_name(sender_name)
+        if not sender:
+            raise UserFriendlyError("Sorry, but this feature is for Community Champions only.")
+
+        return sender


### PR DESCRIPTION
This PR contains 3 main changes:

1. Taking down the Xmas donation module, as the event has now reached its end
2. A bunch of small fixes, mainly early exits, so we don't make API calls or other expensive operations in case there are no changes
3. The Visits module, which is the primary focus of this PR

### Visits module - what it does

People will receive points when they've visited T5 a certain number of times every month. For example, for 5 visits you get 5 points. For 10 visits, you get an additional 10 points and for 20 visits you get an additional 20 points.

These visits are tracked based on the receipts from Loyverse. So every time someone pays their bar tab, it counts as a visit. However, because sometimes there are multiple receipts for one visit, there is supposed to be an 8 hours gap between the receipts for them to count as separate visits.

When people reach one of the checkpoints mentioned above, they receive the points and the bot sends them a direct message if possible. Additionally, people can check their visits by asking the bot.

At first we will just track visits and in a few days we will start awarding the points.

### Visits module - how it's implemented

The User model (and hence the Community Info sheet) has a few new columns:

- Last Visit (last_visit) - `Optional[datetime]` - storing the user's last known visit
- Recent Visits (recent_visits) - `int` - storing the user's total visits in the month of the last known visit
- Visits This Month - this is only in the spreadsheet (we don't need it in the program) and is a formula that displays the Recent Visits or 0, depending on whether the last visit is this month or in the past

There is now a method in the Loyverse integration that retrieves receipts - the raw JSON data is converted to Receipt objects.

The Visits module uses this method to check for new receipts every 5 minutes. The receipts are matched with User models and the receipt creation date is used as the visit date.

The raw visits are then passed to the VisitCalculator helper, which groups them, sorts them, discards old or duplicate visits and eventually returns some updated Users and the checkpoints they reached. There are various edge cases that are being handled: what happens when moving from one month to another, what if the bot is shut down for a while and then restarted, etc. The "happy path" is pretty simple though - because we check every 5 minutes, it's likely that we'll only have one visit to handle at a time.

The checkpoints are read from the config variables (I have already added this config to Heroku). We will start with an empty dictionary of checkpoints, which means that no points will be awarded, but visits will still be tracked.

Based on the checkpoints, we award points and send messages. The points are always awarded but the messages are only sent to users if we have their Telegram ID. They are not announced anywhere else as it would be too spammy.

The bot has not forgotten his trademark sense of humor, so there are a bunch of randomly-chosen messages available when reaching the various checkpoints (many thanks to ChatGPT, whose comedic talent is much better than mine).