### PR TITLE
Fix a critical timezone-related error

### DIFF
--- a/modules/visits.py
+++ b/modules/visits.py
@@ -102,7 +102,7 @@ class VisitsModule(BaseModule):
         right_now = datetime.now(self.timezone)
 
         # Load fresh visits that came in since the last time we checked
-        raw_visits = self.load_visits(self.last_check)
+        raw_visits = self._load_visits(self.last_check)
         updates = self.vc.add_visits(raw_visits, right_now)
 
         # Save the resulting user data to the repository
@@ -114,9 +114,7 @@ class VisitsModule(BaseModule):
         # Remember when we last retrieved new information
         self.last_check = right_now
 
-    def load_visits(self, since: datetime) -> list[Tuple[User, datetime]]:
-        since = since.replace(tzinfo=self.timezone)
-
+    def _load_visits(self, since: datetime) -> list[Tuple[User, datetime]]:
         # Load the receipts and convert them into visits (User + creation date)
         receipts = self.loy.get_receipts(since)
         raw_visits = [self._receipt_to_visit(receipt) for receipt in receipts]


### PR DESCRIPTION
The experience of the last few days has been that the visits in Google Sheets (and the point awards) are not being updated except when the bot is being restarted.

After a **looooot** of debugging, I discovered the reason: I made a mistake in the code that checks Loyverse for receipts, trying to add a timezone to a date that already has a timezone.
It turns out that the pytz timezone for Europe/Bucharest is **not** GMT+2 as you might expect, but LMT +1:44, and pytz does not support outright replacing the timezone of a date - either the date is instantiated with the right timezone or the `localize` method needs to be used. In this case I did not use `localize`, although setting the timezone wasn't even needed in this situation.

The effect of this mistake was that the most recent 16 minutes of receipts were ignored by the bot. We are checking for updates in 2 situations: when the bot is started and then every 5 minutes. Because we are checking every 5 minutes, we were constantly ignoring any new receipts.

I hate this timezone fuckery, but there it is, the fix.